### PR TITLE
Add CSV import to the table editor

### DIFF
--- a/src/Limbo.Umbraco.Tables/Client/src/Components/Table/limbo-table.ts
+++ b/src/Limbo.Umbraco.Tables/Client/src/Components/Table/limbo-table.ts
@@ -4,10 +4,11 @@ import { UmbChangeEvent } from '@umbraco-cms/backoffice/event';
 import type {Table, Cell, Row, Column} from "../../models/table.ts";
 import { UmbSorterController, UmbSorterResolvePlacementAsGrid } from '@umbraco-cms/backoffice/sorter';
 
-import {UMB_MODAL_MANAGER_CONTEXT, type UmbModalManagerContext} from '@umbraco-cms/backoffice/modal';
+import {UMB_MODAL_MANAGER_CONTEXT, umbConfirmModal, type UmbModalManagerContext} from '@umbraco-cms/backoffice/modal';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api'
 import {LIMBO_TABLE_MODAL} from "../Dialogs/RteModalValue.ts";
 import type {UmbPropertyEditorConfigCollection, UmbPropertyEditorUiElement} from "@umbraco-cms/backoffice/property-editor";
+import { parseCsv } from "../../utils/csv.ts";
 
 function clone<T>(value: T): T {
     return JSON.parse(JSON.stringify(value));
@@ -205,10 +206,20 @@ export class LimboTable extends UmbElementMixin(LitElement) implements UmbProper
                         <uui-icon name="icon-add"></uui-icon>
                         ${this.localize.term("limboTables_addColumn")}
                     </uui-button>
+                    <uui-button pristine="" label="${this.localize.term("limboTables_importCsv")}" look="secondary" @click="${this.#triggerCsvImport}">
+                        <uui-icon name="icon-download"></uui-icon>
+                        ${this.localize.term("limboTables_importCsv")}
+                    </uui-button>
                     <uui-button pristine="" label="Reset" look="secondary" @click="${this.reset}">
                         <uui-icon name="icon-add"></uui-icon>
                         Reset
                     </uui-button>
+                    <input
+                        id="csv-import-input"
+                        type="file"
+                        accept=".csv,text/csv"
+                        hidden
+                        @change="${this.#onCsvFileChange}" />
                 </div>
             </div>
         `;
@@ -308,6 +319,87 @@ export class LimboTable extends UmbElementMixin(LitElement) implements UmbProper
             cells: undefined
         };
         this.updateUi();
+    }
+
+    #triggerCsvImport() {
+        this.shadowRoot?.querySelector<HTMLInputElement>("#csv-import-input")?.click();
+    }
+
+    async #onCsvFileChange(event: Event) {
+
+        const input = event.target as HTMLInputElement | null;
+        const file = input?.files?.[0];
+
+        // Reset the input so picking the same file again still raises a change event
+        if (input) input.value = "";
+        if (!file) return;
+
+        try {
+            await this.#importCsv(await file.text());
+        } catch (e) {
+            console.error("Failed to import CSV:", e);
+        }
+
+    }
+
+    async #importCsv(text: string) {
+
+        const records = parseCsv(text);
+        if (records.length === 0) return;
+
+        // Importing replaces the table, so confirm before discarding existing content
+        if (this.#hasContent()) {
+            try {
+                await umbConfirmModal(this, {
+                    headline: this.localize.term("limboTables_importCsv"),
+                    content: this.localize.term("limboTables_importCsvConfirm"),
+                    confirmLabel: this.localize.term("limboTables_importCsvConfirmLabel"),
+                    color: "danger"
+                });
+            } catch {
+                return;
+            }
+        }
+
+        this.table.columns = records[0].map(() => ({ id: crypto.randomUUID() }));
+
+        this.table.rows = records.map((values, rowIndex) => ({
+            id: crypto.randomUUID(),
+            cells: values.map((value, columnIndex) => ({
+                ...this.getEmptyCell(rowIndex, columnIndex),
+                value: this.#toCellHtml(value)
+            }))
+        }));
+
+        // Cells are stored on the rows - the legacy top level array must not linger
+        this.table.cells = undefined;
+
+        this.reIndexCells();
+        this.updateUi();
+
+    }
+
+    #hasContent() {
+        return this.table.rows.some(row => row.cells.some(cell => (cell.value?.length ?? 0) > 0));
+    }
+
+    #toCellHtml(value: string) {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) return "";
+        // Cell values are rich text, so each line of a multi line CSV field becomes a paragraph
+        return trimmed
+            .split(/\r?\n/)
+            .map(line => `<p>${this.#escapeHtml(line)}</p>`)
+            .join("");
+    }
+
+    #escapeHtml(value: string) {
+        return value
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
     }
 
     #syncSorters() {

--- a/src/Limbo.Umbraco.Tables/Client/src/Lang/da.ts
+++ b/src/Limbo.Umbraco.Tables/Client/src/Lang/da.ts
@@ -9,5 +9,8 @@ export default {
         addCellContent: 'Tilføj cellens indhold',
         editCellContent: 'Redigér cellens indhold',
         useTextareaEditor: 'Brug tekstboks til celleeditor i stedet for RTE',
+        importCsv: 'Importér CSV',
+        importCsvConfirm: 'Import af en CSV-fil erstatter tabellens nuværende indhold. Vil du fortsætte?',
+        importCsvConfirmLabel: 'Importér',
     },
 };

--- a/src/Limbo.Umbraco.Tables/Client/src/Lang/en.ts
+++ b/src/Limbo.Umbraco.Tables/Client/src/Lang/en.ts
@@ -9,5 +9,8 @@ export default {
         addCellContent: 'Add cell content',
         editCellContent: 'Edit cell content',
         useTextareaEditor: 'Use textarea cell editor instead of RTE',
+        importCsv: 'Import CSV',
+        importCsvConfirm: 'Importing a CSV file replaces the current contents of the table. Do you want to continue?',
+        importCsvConfirmLabel: 'Import',
     },
 };

--- a/src/Limbo.Umbraco.Tables/Client/src/utils/csv.ts
+++ b/src/Limbo.Umbraco.Tables/Client/src/utils/csv.ts
@@ -1,0 +1,179 @@
+/**
+ * Minimal RFC 4180 CSV reader.
+ *
+ * Handles quoted fields (`"a,b"`), escaped quotes (`""`), newlines inside quoted
+ * fields, CRLF/LF line endings and a leading UTF-8 BOM. The delimiter is detected
+ * automatically, as spreadsheet software in several locales exports semicolon
+ * separated files rather than comma separated ones.
+ */
+
+const CANDIDATE_DELIMITERS = [",", ";", "\t", "|"];
+
+/** Number of leading characters considered when detecting the delimiter. */
+const DETECTION_SAMPLE_LENGTH = 65536;
+
+/** Number of leading records considered when detecting the delimiter. */
+const DETECTION_SAMPLE_RECORDS = 10;
+
+function stripBom(text: string): string {
+    return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/**
+ * Splits `text` into records using the specified `delimiter`.
+ *
+ * Unquoted fields are trimmed, as leading and trailing whitespace around a
+ * delimiter is rarely intentional. Quoted fields are returned verbatim.
+ */
+function tokenize(text: string, delimiter: string): string[][] {
+
+    const records: string[][] = [];
+
+    let record: string[] = [];
+    let field = "";
+    let quoted = false;
+    let wasQuoted = false;
+    let index = 0;
+
+    const endField = () => {
+        record.push(wasQuoted ? field : field.trim());
+        field = "";
+        wasQuoted = false;
+    };
+
+    const endRecord = () => {
+        endField();
+        records.push(record);
+        record = [];
+    };
+
+    while (index < text.length) {
+
+        const character = text[index];
+
+        if (quoted) {
+            if (character === "\"") {
+                // A doubled quote inside a quoted field is an escaped quote
+                if (text[index + 1] === "\"") {
+                    field += "\"";
+                    index += 2;
+                    continue;
+                }
+                quoted = false;
+                index++;
+                continue;
+            }
+            field += character;
+            index++;
+            continue;
+        }
+
+        // A quote only opens a quoted field when it appears at the start of the field
+        if (character === "\"" && field.length === 0) {
+            quoted = true;
+            wasQuoted = true;
+            index++;
+            continue;
+        }
+
+        if (character === delimiter) {
+            endField();
+            index++;
+            continue;
+        }
+
+        if (character === "\r" || character === "\n") {
+            endRecord();
+            index += character === "\r" && text[index + 1] === "\n" ? 2 : 1;
+            continue;
+        }
+
+        field += character;
+        index++;
+
+    }
+
+    endRecord();
+
+    // Drop records that are entirely empty - typically the trailing newline
+    return records.filter(x => x.some(y => y.length > 0));
+
+}
+
+/**
+ * Determines which delimiter `text` most likely uses.
+ *
+ * A real delimiter splits every record into the same number of columns, so each
+ * candidate is scored by its most common column count weighted by how many of the
+ * sampled records actually agree on it. Weighting by agreement matters: a comma is
+ * a decimal separator in several locales, and would otherwise beat the semicolon
+ * that actually separates the columns by shredding a few records into many fields.
+ */
+export function detectDelimiter(text: string): string {
+
+    const sample = text.slice(0, DETECTION_SAMPLE_LENGTH);
+
+    let bestDelimiter = CANDIDATE_DELIMITERS[0];
+    let bestScore = 0;
+
+    for (const delimiter of CANDIDATE_DELIMITERS) {
+
+        const records = tokenize(sample, delimiter).slice(0, DETECTION_SAMPLE_RECORDS);
+        if (records.length === 0) continue;
+
+        const widths = records.map(x => x.length);
+
+        // Find the most common column count, preferring the wider one on a tie
+        const occurrences = new Map<number, number>();
+        for (const width of widths) occurrences.set(width, (occurrences.get(width) ?? 0) + 1);
+
+        let commonWidth = 0;
+        let commonCount = 0;
+        for (const [width, count] of occurrences) {
+            if (count > commonCount || (count === commonCount && width > commonWidth)) {
+                commonWidth = width;
+                commonCount = count;
+            }
+        }
+
+        // A delimiter that never splits a record is not a delimiter
+        if (commonWidth < 2) continue;
+
+        const score = commonWidth * (commonCount / widths.length);
+
+        if (score > bestScore) {
+            bestScore = score;
+            bestDelimiter = delimiter;
+        }
+
+    }
+
+    return bestDelimiter;
+
+}
+
+/**
+ * Parses `text` into a rectangular grid of cell values.
+ *
+ * Short records are padded with empty strings so every returned record has the
+ * same length, matching the table editor's model.
+ *
+ * @param text The CSV content to parse.
+ * @param delimiter The delimiter to use. Detected automatically when not specified.
+ * @returns A rectangular array of records, or an empty array if `text` holds no data.
+ */
+export function parseCsv(text: string, delimiter?: string): string[][] {
+
+    const input = stripBom(text);
+    if (input.length === 0) return [];
+
+    const records = tokenize(input, delimiter ?? detectDelimiter(input));
+    if (records.length === 0) return [];
+
+    const width = records.reduce((max, record) => Math.max(max, record.length), 0);
+
+    return records.map(record => record.length === width
+        ? record
+        : [...record, ...new Array<string>(width - record.length).fill("")]);
+
+}


### PR DESCRIPTION
Adds an **Import CSV** action to the table editor, so an editor can populate a table from a spreadsheet export instead of building it cell by cell.

This is the closest thing I had to hand for #27 — it doesn't do copy/paste between properties, but it covers the "I already have this data in a spreadsheet" half of that problem. Happy to drop or rework it if it doesn't fit where you're taking the editor in #49.

## What it does

A new button next to Add row / Add column opens a file picker and replaces the table with the file's contents. Because it replaces, it asks for confirmation first — but only when the table already has content, so importing into a fresh property stays a single click.

## The parser

`Client/src/utils/csv.ts` is a small RFC 4180 reader, kept separate from the component so it can be read and reasoned about on its own. It handles quoted fields, `""` escaped quotes, newlines inside quoted fields, CRLF/LF, and a leading UTF-8 BOM. Unquoted fields are trimmed; quoted fields are left verbatim.

The one part worth a second look is delimiter detection. Assuming a comma is wrong — Excel exports semicolon separated files in several locales, and in exactly those locales the comma is also the decimal separator. So each candidate (`,` `;` tab `|`) is scored by its **most common** column count, weighted by how many records agree on it. Scoring by the *widest* result instead makes the comma win on a file like this, by shredding two of the records into four fields each:

```
Produto;Preco;Notas
"Cabo, 2m";1,50;"Diz ""ola"""
```

## Fitting the current editor model

- Rows and columns are created with `crypto.randomUUID()` ids, matching `addRow()` / `addColumnAction()`, so `UmbSorterController` keeps working after an import.
- Cells are written to `row.cells`; `table.cells` is explicitly left `undefined` so the import never produces the legacy shape that `TablesJsonParser.TryParseLegacyCellsArray` exists to read.
- Short records are padded so the grid stays rectangular.
- Values are HTML escaped and wrapped in paragraphs to match how the RTE stores them; a multi-line field becomes one paragraph per line.

Localisation keys added to both `en.ts` and `da.ts` (`importCsv`, `importCsvConfirm`, `importCsvConfirmLabel`).

## Testing

Verified against a clean Umbraco 17.2.2 instance with this branch referenced as a project.

The parser was checked against 23 cases: quoted commas, escaped quotes, newlines in quotes, BOM, CRLF, ragged rows padded, blank lines dropped, empty/whitespace-only input, trailing delimiter, unterminated quote, explicit delimiter overriding detection, and detection for all four candidates including the decimal-comma case above. I left the test file out of the diff since there's no frontend test runner in the repo — glad to add it along with vitest if you'd want that.

Sample file used for the manual test:

```
Produto;Preco;Notas
"Cabo, 2m";1,50;"Diz ""ola"""
Adaptador;12,00;Sem notas
"Multi
linha";3,75;
```

Which imports as 4 rows × 3 columns: the `;` is detected despite the decimal commas, `Cabo, 2m` stays in one cell, `Diz "ola"` is unescaped, `Multi`/`linha` becomes two paragraphs in a single cell, and the trailing empty field is preserved as a real third column. Rows and columns still drag afterwards, and the value round-trips through save and reload.

And the plain comma case:

```
Name,Role
Ada,"Engineer, lead"
Grace,Admiral
```

Refs #27
